### PR TITLE
Annotate terminal parsing components with explanatory comments

### DIFF
--- a/Sources/TerminalInput/AnsiFormat+Attributes.swift
+++ b/Sources/TerminalInput/AnsiFormat+Attributes.swift
@@ -2,17 +2,30 @@ import Foundation
 
 extension TerminalInput.AnsiFormat {
 
+  /// Describes the stylistic effects that an SGR sequence requests.  Each flag
+  /// mirrors an aspect of the way text can be drawn on screen, such as boldness
+  /// or foreground colour.
   public struct Attributes : Equatable {
 
+    /// Indicates whether the sequence requested a full reset of prior styling.
     public var isReset       : Bool
+    /// True when the sequence enables bold text.
     public var isBold        : Bool
+    /// True when the sequence enables faint (dim) text.
     public var isFaint       : Bool
+    /// True when the sequence enables italic text.
     public var isItalic      : Bool
+    /// True when the sequence enables underlined text.
     public var isUnderlined  : Bool
+    /// True when foreground and background colours should be swapped.
     public var isInverse     : Bool
+    /// Optional foreground colour requested by the sequence.
     public var foreground    : Color?
+    /// Optional background colour requested by the sequence.
     public var background    : Color?
 
+    /// Internal bookkeeping so that the parser can tell whether a property was
+    /// explicitly set or merely inherited from previous state.
     internal var didReset            : Bool
     internal var boldSpecified       : Bool
     internal var faintSpecified      : Bool
@@ -22,6 +35,7 @@ extension TerminalInput.AnsiFormat {
     internal var foregroundSpecified : Bool
     internal var backgroundSpecified : Bool
 
+    /// Initialiser with defaults that match the “plain text” look.
     public init ( isReset: Bool = false,
                   isBold: Bool = false,
                   isFaint: Bool = false,
@@ -48,6 +62,9 @@ extension TerminalInput.AnsiFormat {
       self.backgroundSpecified = background != nil
     }
 
+    /// Equality respects only the user-visible aspects so that different
+    /// bookkeeping states compare as identical when they lead to the same
+    /// visual outcome.
     public static func == ( lhs: Attributes, rhs: Attributes ) -> Bool {
       return lhs.isReset      == rhs.isReset
           && lhs.isBold       == rhs.isBold
@@ -59,6 +76,7 @@ extension TerminalInput.AnsiFormat {
           && lhs.background   == rhs.background
     }
 
+    /// The eight classic colours defined by the ANSI standard.
     public enum StandardColor : Int, Equatable {
       case black = 0
       case red
@@ -70,10 +88,15 @@ extension TerminalInput.AnsiFormat {
       case white
     }
 
+    /// All possible ways the terminal can express colour.
     public enum Color : Equatable {
+      /// One of the eight standard colours.
       case standard(StandardColor)
+      /// One of the eight “bright” variants, sometimes called high intensity.
       case bright(StandardColor)
+      /// An index into the 256-colour lookup table that modern terminals offer.
       case palette(UInt8)
+      /// A true-colour red/green/blue triple.
       case rgb(red: UInt8, green: UInt8, blue: UInt8)
     }
 

--- a/Sources/TerminalInput/AttributeParser.swift
+++ b/Sources/TerminalInput/AttributeParser.swift
@@ -2,6 +2,9 @@ import Foundation
 
 extension TerminalInput.AnsiFormat {
 
+  /// A succinct description of the changes that an SGR sequence applies.  Using
+  /// this intermediate representation makes it easy for calling code to switch
+  /// over individual effects without needing to inspect several boolean flags.
   public enum Attribute : Equatable {
     case reset
     case bold(Bool)
@@ -13,10 +16,16 @@ extension TerminalInput.AnsiFormat {
     case background(Attributes.Color)
   }
 
+  /// Turns the parsed attribute structure into an ordered list of changes.  This
+  /// is handy when replaying styles to another output device or when explaining
+  /// the meaning of an escape sequence to learners.
   public struct AttributeParser {
 
     public init () { }
 
+    /// Extracts the individual `Attribute` values that were explicitly provided
+    /// by the original escape sequence.  Properties that were not mentioned are
+    /// skipped so that the caller sees only the actions that occurred.
     public func parse ( attributes: Attributes ) -> [Attribute] {
       var result : [Attribute] = []
       if attributes.didReset || attributes.isReset {


### PR DESCRIPTION
## Summary
- document TerminalInput tokens, helpers, and parsing flow so newcomers can follow how the byte stream is decoded
- explain ANSI format attribute structures, including references to relevant xterm control sequence documentation

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e3d4bce3588328a4dc06286d9b46d0