### PR TITLE
Refactor attribute bookkeeping to use specified set

### DIFF
--- a/Sources/TerminalInput/AnsiFormat+Attributes.swift
+++ b/Sources/TerminalInput/AnsiFormat+Attributes.swift
@@ -26,14 +26,18 @@ extension TerminalInput.AnsiFormat {
 
     /// Internal bookkeeping so that the parser can tell whether a property was
     /// explicitly set or merely inherited from previous state.
-    internal var didReset            : Bool
-    internal var boldSpecified       : Bool
-    internal var faintSpecified      : Bool
-    internal var italicSpecified     : Bool
-    internal var underlinedSpecified : Bool
-    internal var inverseSpecified    : Bool
-    internal var foregroundSpecified : Bool
-    internal var backgroundSpecified : Bool
+    internal var specified      : Set<SpecifiedAttribute>
+
+    internal enum SpecifiedAttribute : Hashable {
+      case reset
+      case bold
+      case faint
+      case italic
+      case underlined
+      case inverse
+      case foreground
+      case background
+    }
 
     /// Initialiser with defaults that match the “plain text” look.
     public init ( isReset: Bool = false,
@@ -52,14 +56,31 @@ extension TerminalInput.AnsiFormat {
       self.isInverse           = isInverse
       self.foreground          = foreground
       self.background          = background
-      self.didReset            = isReset
-      self.boldSpecified       = isBold
-      self.faintSpecified      = isFaint
-      self.italicSpecified     = isItalic
-      self.underlinedSpecified = isUnderlined
-      self.inverseSpecified    = isInverse
-      self.foregroundSpecified = foreground != nil
-      self.backgroundSpecified = background != nil
+      self.specified           = []
+      if isReset      { mark(.reset) }
+      if isBold       { mark(.bold) }
+      if isFaint      { mark(.faint) }
+      if isItalic     { mark(.italic) }
+      if isUnderlined { mark(.underlined) }
+      if isInverse    { mark(.inverse) }
+      if foreground   != nil { mark(.foreground) }
+      if background   != nil { mark(.background) }
+    }
+
+    internal mutating func mark ( _ attribute: SpecifiedAttribute ) {
+      specified.insert(attribute)
+    }
+
+    internal mutating func unmark ( _ attribute: SpecifiedAttribute ) {
+      specified.remove(attribute)
+    }
+
+    internal mutating func clearMarks () {
+      specified.removeAll()
+    }
+
+    internal func isSpecified ( _ attribute: SpecifiedAttribute ) -> Bool {
+      return specified.contains(attribute)
     }
 
     /// Equality respects only the user-visible aspects so that different

--- a/Sources/TerminalInput/AttributeParser.swift
+++ b/Sources/TerminalInput/AttributeParser.swift
@@ -28,29 +28,39 @@ extension TerminalInput.AnsiFormat {
     /// skipped so that the caller sees only the actions that occurred.
     public func parse ( attributes: Attributes ) -> [Attribute] {
       var result : [Attribute] = []
-      if attributes.didReset || attributes.isReset {
-        result.append(.reset)
-      }
-      if attributes.boldSpecified {
-        result.append(.bold(attributes.isBold))
-      }
-      if attributes.faintSpecified {
-        result.append(.faint(attributes.isFaint))
-      }
-      if attributes.italicSpecified {
-        result.append(.italic(attributes.isItalic))
-      }
-      if attributes.underlinedSpecified {
-        result.append(.underlined(attributes.isUnderlined))
-      }
-      if attributes.inverseSpecified {
-        result.append(.inverse(attributes.isInverse))
-      }
-      if attributes.foregroundSpecified, let foreground = attributes.foreground {
-        result.append(.foreground(foreground))
-      }
-      if attributes.backgroundSpecified, let background = attributes.background {
-        result.append(.background(background))
+      let order : [Attributes.SpecifiedAttribute] = [
+        .reset,
+        .bold,
+        .faint,
+        .italic,
+        .underlined,
+        .inverse,
+        .foreground,
+        .background,
+      ]
+      for attribute in order where attributes.isSpecified(attribute) {
+        switch attribute {
+          case .reset:
+            result.append(.reset)
+          case .bold:
+            result.append(.bold(attributes.isBold))
+          case .faint:
+            result.append(.faint(attributes.isFaint))
+          case .italic:
+            result.append(.italic(attributes.isItalic))
+          case .underlined:
+            result.append(.underlined(attributes.isUnderlined))
+          case .inverse:
+            result.append(.inverse(attributes.isInverse))
+          case .foreground:
+            if let foreground = attributes.foreground {
+              result.append(.foreground(foreground))
+            }
+          case .background:
+            if let background = attributes.background {
+              result.append(.background(background))
+            }
+        }
       }
       return result
     }

--- a/Sources/TerminalInput/TerminalInput.swift
+++ b/Sources/TerminalInput/TerminalInput.swift
@@ -458,68 +458,68 @@ public final class TerminalInput {
         case 1:
           attributes.isBold        = true
           attributes.isReset       = false
-          attributes.boldSpecified = true
+          attributes.mark(.bold)
         case 2:
-          attributes.isFaint        = true
-          attributes.isReset        = false
-          attributes.faintSpecified = true
+          attributes.isFaint       = true
+          attributes.isReset       = false
+          attributes.mark(.faint)
         case 3:
           attributes.isItalic        = true
           attributes.isReset         = false
-          attributes.italicSpecified = true
+          attributes.mark(.italic)
         case 4:
           attributes.isUnderlined        = true
           attributes.isReset             = false
-          attributes.underlinedSpecified = true
+          attributes.mark(.underlined)
         case 7:
-          attributes.isInverse        = true
-          attributes.isReset          = false
-          attributes.inverseSpecified = true
+          attributes.isInverse         = true
+          attributes.isReset           = false
+          attributes.mark(.inverse)
         case 22:
-          attributes.isBold        = false
-          attributes.isFaint       = false
-          attributes.isReset       = false
-          attributes.boldSpecified = true
-          attributes.faintSpecified = true
+          attributes.isBold            = false
+          attributes.isFaint           = false
+          attributes.isReset           = false
+          attributes.mark(.bold)
+          attributes.mark(.faint)
         case 23:
           attributes.isItalic        = false
           attributes.isReset         = false
-          attributes.italicSpecified = true
+          attributes.mark(.italic)
         case 24:
           attributes.isUnderlined        = false
           attributes.isReset             = false
-          attributes.underlinedSpecified = true
+          attributes.mark(.underlined)
         case 27:
-          attributes.isInverse        = false
-          attributes.isReset          = false
-          attributes.inverseSpecified = true
+          attributes.isInverse         = false
+          attributes.isReset           = false
+          attributes.mark(.inverse)
         case 30 ... 37:
-          attributes.foreground           = .standard( standardColor(from: value - 30) )
-          attributes.foregroundSpecified  = true
-          attributes.isReset              = false
+          attributes.foreground = .standard( standardColor(from: value - 30) )
+          attributes.mark(.foreground)
+          attributes.isReset     = false
         case 40 ... 47:
-          attributes.background           = .standard( standardColor(from: value - 40) )
-          attributes.backgroundSpecified  = true
-          attributes.isReset              = false
+          attributes.background = .standard( standardColor(from: value - 40) )
+          attributes.mark(.background)
+          attributes.isReset     = false
         case 90 ... 97:
-          attributes.foreground           = .bright( standardColor(from: value - 90) )
-          attributes.foregroundSpecified  = true
-          attributes.isReset              = false
+          attributes.foreground = .bright( standardColor(from: value - 90) )
+          attributes.mark(.foreground)
+          attributes.isReset     = false
         case 100 ... 107:
-          attributes.background           = .bright( standardColor(from: value - 100) )
-          attributes.backgroundSpecified  = true
-          attributes.isReset              = false
+          attributes.background = .bright( standardColor(from: value - 100) )
+          attributes.mark(.background)
+          attributes.isReset     = false
         case 38:
           if let color = parseExtendedColor(values: values, index: &index) {
-            attributes.foreground          = color
-            attributes.foregroundSpecified = true
-            attributes.isReset             = false
+            attributes.foreground = color
+            attributes.mark(.foreground)
+            attributes.isReset    = false
           }
         case 48:
           if let color = parseExtendedColor(values: values, index: &index) {
-            attributes.background          = color
-            attributes.backgroundSpecified = true
-            attributes.isReset             = false
+            attributes.background = color
+            attributes.mark(.background)
+            attributes.isReset    = false
           }
         default:
           break
@@ -533,22 +533,17 @@ public final class TerminalInput {
   /// ANSI defines SGR 0 as a full reset, so this helper applies the same idea to
   /// the high level structure.
   private func resetAttributes () -> AnsiFormat.Attributes {
-    var attributes = AnsiFormat.Attributes(isReset: true)
-    attributes.didReset            = true
-    attributes.isBold              = false
-    attributes.isFaint             = false
-    attributes.isItalic            = false
-    attributes.isUnderlined        = false
-    attributes.isInverse           = false
-    attributes.foreground          = nil
-    attributes.background          = nil
-    attributes.boldSpecified       = false
-    attributes.faintSpecified      = false
-    attributes.italicSpecified     = false
-    attributes.underlinedSpecified = false
-    attributes.inverseSpecified    = false
-    attributes.foregroundSpecified = false
-    attributes.backgroundSpecified = false
+    var attributes = AnsiFormat.Attributes()
+    attributes.isReset      = true
+    attributes.isBold       = false
+    attributes.isFaint      = false
+    attributes.isItalic     = false
+    attributes.isUnderlined = false
+    attributes.isInverse    = false
+    attributes.foreground   = nil
+    attributes.background   = nil
+    attributes.clearMarks()
+    attributes.mark(.reset)
     return attributes
   }
 


### PR DESCRIPTION
## Summary
- replace the internal attribute bookkeeping booleans with a SpecifiedAttribute set
- update SGR parsing and resets to mark attributes through the new helper API
- emit parsed attributes by iterating the set in AttributeParser to preserve ordering

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e3db78bdec83288b863833283323f3