### PR TITLE
Accept format set in Attributes initializer

### DIFF
--- a/Sources/TerminalInput/AnsiFormat+Attributes.swift
+++ b/Sources/TerminalInput/AnsiFormat+Attributes.swift
@@ -7,26 +7,27 @@ extension TerminalInput.AnsiFormat {
   /// or foreground colour.
   public struct Attributes : Equatable {
 
-    /// Indicates whether the sequence requested a full reset of prior styling.
-    public var isReset       : Bool
-    /// True when the sequence enables bold text.
-    public var isBold        : Bool
-    /// True when the sequence enables faint (dim) text.
-    public var isFaint       : Bool
-    /// True when the sequence enables italic text.
-    public var isItalic      : Bool
-    /// True when the sequence enables underlined text.
-    public var isUnderlined  : Bool
-    /// True when foreground and background colours should be swapped.
-    public var isInverse     : Bool
+    /// Flags that describe stylistic effects such as bold, underline, or reset.
+    public var formats      : Set<Format>
     /// Optional foreground colour requested by the sequence.
-    public var foreground    : Color?
+    public var foreground   : Color?
     /// Optional background colour requested by the sequence.
-    public var background    : Color?
+    public var background   : Color?
 
     /// Internal bookkeeping so that the parser can tell whether a property was
     /// explicitly set or merely inherited from previous state.
-    internal var specified      : Set<SpecifiedAttribute>
+    internal var specified   : Set<SpecifiedAttribute>
+
+    /// Boolean-style flags expressed as a set so that styles can be added and
+    /// removed without tracking individual booleans.
+    public enum Format : Hashable {
+      case isReset
+      case isBold
+      case isFaint
+      case isItalic
+      case isUnderlined
+      case isInverse
+    }
 
     internal enum SpecifiedAttribute : Hashable {
       case reset
@@ -40,29 +41,19 @@ extension TerminalInput.AnsiFormat {
     }
 
     /// Initialiser with defaults that match the “plain text” look.
-    public init ( isReset: Bool = false,
-                  isBold: Bool = false,
-                  isFaint: Bool = false,
-                  isItalic: Bool = false,
-                  isUnderlined: Bool = false,
-                  isInverse: Bool = false,
+    public init ( formats: Set<Format> = [],
                   foreground: Color? = nil,
                   background: Color? = nil ) {
-      self.isReset             = isReset
-      self.isBold              = isBold
-      self.isFaint             = isFaint
-      self.isItalic            = isItalic
-      self.isUnderlined        = isUnderlined
-      self.isInverse           = isInverse
+      self.formats             = formats
       self.foreground          = foreground
       self.background          = background
       self.specified           = []
-      if isReset      { mark(.reset) }
-      if isBold       { mark(.bold) }
-      if isFaint      { mark(.faint) }
-      if isItalic     { mark(.italic) }
-      if isUnderlined { mark(.underlined) }
-      if isInverse    { mark(.inverse) }
+      if formats.contains(.isReset)      { mark(.reset) }
+      if formats.contains(.isBold)       { mark(.bold) }
+      if formats.contains(.isFaint)      { mark(.faint) }
+      if formats.contains(.isItalic)     { mark(.italic) }
+      if formats.contains(.isUnderlined) { mark(.underlined) }
+      if formats.contains(.isInverse)    { mark(.inverse) }
       if foreground   != nil { mark(.foreground) }
       if background   != nil { mark(.background) }
     }
@@ -87,12 +78,7 @@ extension TerminalInput.AnsiFormat {
     /// bookkeeping states compare as identical when they lead to the same
     /// visual outcome.
     public static func == ( lhs: Attributes, rhs: Attributes ) -> Bool {
-      return lhs.isReset      == rhs.isReset
-          && lhs.isBold       == rhs.isBold
-          && lhs.isFaint      == rhs.isFaint
-          && lhs.isItalic     == rhs.isItalic
-          && lhs.isUnderlined == rhs.isUnderlined
-          && lhs.isInverse    == rhs.isInverse
+      return lhs.formats     == rhs.formats
           && lhs.foreground   == rhs.foreground
           && lhs.background   == rhs.background
     }

--- a/Sources/TerminalInput/AttributeParser.swift
+++ b/Sources/TerminalInput/AttributeParser.swift
@@ -43,15 +43,15 @@ extension TerminalInput.AnsiFormat {
           case .reset:
             result.append(.reset)
           case .bold:
-            result.append(.bold(attributes.isBold))
+            result.append(.bold(attributes.formats.contains(.isBold)))
           case .faint:
-            result.append(.faint(attributes.isFaint))
+            result.append(.faint(attributes.formats.contains(.isFaint)))
           case .italic:
-            result.append(.italic(attributes.isItalic))
+            result.append(.italic(attributes.formats.contains(.isItalic)))
           case .underlined:
-            result.append(.underlined(attributes.isUnderlined))
+            result.append(.underlined(attributes.formats.contains(.isUnderlined)))
           case .inverse:
-            result.append(.inverse(attributes.isInverse))
+            result.append(.inverse(attributes.formats.contains(.isInverse)))
           case .foreground:
             if let foreground = attributes.foreground {
               result.append(.foreground(foreground))

--- a/Sources/TerminalInput/TerminalInput.swift
+++ b/Sources/TerminalInput/TerminalInput.swift
@@ -456,70 +456,70 @@ public final class TerminalInput {
         case 0:
           attributes = resetAttributes()
         case 1:
-          attributes.isBold        = true
-          attributes.isReset       = false
+          attributes.formats.insert(.isBold)
+          attributes.formats.remove(.isReset)
           attributes.mark(.bold)
         case 2:
-          attributes.isFaint       = true
-          attributes.isReset       = false
+          attributes.formats.insert(.isFaint)
+          attributes.formats.remove(.isReset)
           attributes.mark(.faint)
         case 3:
-          attributes.isItalic        = true
-          attributes.isReset         = false
+          attributes.formats.insert(.isItalic)
+          attributes.formats.remove(.isReset)
           attributes.mark(.italic)
         case 4:
-          attributes.isUnderlined        = true
-          attributes.isReset             = false
+          attributes.formats.insert(.isUnderlined)
+          attributes.formats.remove(.isReset)
           attributes.mark(.underlined)
         case 7:
-          attributes.isInverse         = true
-          attributes.isReset           = false
+          attributes.formats.insert(.isInverse)
+          attributes.formats.remove(.isReset)
           attributes.mark(.inverse)
         case 22:
-          attributes.isBold            = false
-          attributes.isFaint           = false
-          attributes.isReset           = false
+          attributes.formats.remove(.isBold)
+          attributes.formats.remove(.isFaint)
+          attributes.formats.remove(.isReset)
           attributes.mark(.bold)
           attributes.mark(.faint)
         case 23:
-          attributes.isItalic        = false
-          attributes.isReset         = false
+          attributes.formats.remove(.isItalic)
+          attributes.formats.remove(.isReset)
           attributes.mark(.italic)
         case 24:
-          attributes.isUnderlined        = false
-          attributes.isReset             = false
+          attributes.formats.remove(.isUnderlined)
+          attributes.formats.remove(.isReset)
           attributes.mark(.underlined)
         case 27:
-          attributes.isInverse         = false
-          attributes.isReset           = false
+          attributes.formats.remove(.isInverse)
+          attributes.formats.remove(.isReset)
           attributes.mark(.inverse)
         case 30 ... 37:
           attributes.foreground = .standard( standardColor(from: value - 30) )
           attributes.mark(.foreground)
-          attributes.isReset     = false
+          attributes.formats.remove(.isReset)
         case 40 ... 47:
           attributes.background = .standard( standardColor(from: value - 40) )
           attributes.mark(.background)
-          attributes.isReset     = false
+          attributes.formats.remove(.isReset)
         case 90 ... 97:
           attributes.foreground = .bright( standardColor(from: value - 90) )
           attributes.mark(.foreground)
-          attributes.isReset     = false
+          attributes.formats.remove(.isReset)
         case 100 ... 107:
           attributes.background = .bright( standardColor(from: value - 100) )
           attributes.mark(.background)
-          attributes.isReset     = false
+          attributes.formats.remove(.isReset)
         case 38:
           if let color = parseExtendedColor(values: values, index: &index) {
             attributes.foreground = color
             attributes.mark(.foreground)
-            attributes.isReset    = false
+            attributes.formats.remove(.isReset)
           }
         case 48:
           if let color = parseExtendedColor(values: values, index: &index) {
             attributes.background = color
             attributes.mark(.background)
-            attributes.isReset    = false
+            attributes.formats.remove(.isReset)
           }
         default:
           break
@@ -533,13 +533,7 @@ public final class TerminalInput {
   /// ANSI defines SGR 0 as a full reset, so this helper applies the same idea to
   /// the high level structure.
   private func resetAttributes () -> AnsiFormat.Attributes {
-    var attributes = AnsiFormat.Attributes()
-    attributes.isReset      = true
-    attributes.isBold       = false
-    attributes.isFaint      = false
-    attributes.isItalic     = false
-    attributes.isUnderlined = false
-    attributes.isInverse    = false
+    var attributes = AnsiFormat.Attributes(formats: [.isReset])
     attributes.foreground   = nil
     attributes.background   = nil
     attributes.clearMarks()

--- a/Tests/TerminalInputTests/TerminalInputTests.swift
+++ b/Tests/TerminalInputTests/TerminalInputTests.swift
@@ -35,7 +35,7 @@ final class TerminalInputTests: XCTestCase {
   func testSGRParsing () {
     let data    = Data("\u{001B}[1;31m".utf8)
     let tokens  = captureTokens(from: data)
-    let expectedAttributes = TerminalInput.AnsiFormat.Attributes(isBold: true,
+    let expectedAttributes = TerminalInput.AnsiFormat.Attributes(formats: [.isBold],
                                                                  foreground: .standard(.red))
     let expected = TerminalInput.Token.ansi( TerminalInput.AnsiFormat(sequence: "\u{001B}[1;31m",
                                                                       attributes: expectedAttributes) )
@@ -85,7 +85,7 @@ final class TerminalInputTests: XCTestCase {
     }
 
     XCTAssertEqual(formatToken.sequence, "\u{001B}[1;31m")
-    XCTAssertTrue(formatToken.attributes.isBold)
+    XCTAssertTrue(formatToken.attributes.formats.contains(.isBold))
   }
 
   func testAttributeParserEnumeratesAttributes () {


### PR DESCRIPTION
## Summary
- update `AnsiFormat.Attributes` to accept a `Set<Format>` when initializing
- adjust reset handling and tests to construct attributes with the new signature

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e3ed94822c83288db261c6270f46fc