### PR TITLE
Refactor ANSI attribute state handling

### DIFF
--- a/Sources/TerminalInput/AttributeParser.swift
+++ b/Sources/TerminalInput/AttributeParser.swift
@@ -43,15 +43,15 @@ extension TerminalInput.AnsiFormat {
           case .reset:
             result.append(.reset)
           case .bold:
-            result.append(.bold(attributes.formats.contains(.isBold)))
+            result.append(.bold(attributes.isAttributeEnabled(.bold) ?? false))
           case .faint:
-            result.append(.faint(attributes.formats.contains(.isFaint)))
+            result.append(.faint(attributes.isAttributeEnabled(.faint) ?? false))
           case .italic:
-            result.append(.italic(attributes.formats.contains(.isItalic)))
+            result.append(.italic(attributes.isAttributeEnabled(.italic) ?? false))
           case .underlined:
-            result.append(.underlined(attributes.formats.contains(.isUnderlined)))
+            result.append(.underlined(attributes.isAttributeEnabled(.underlined) ?? false))
           case .inverse:
-            result.append(.inverse(attributes.formats.contains(.isInverse)))
+            result.append(.inverse(attributes.isAttributeEnabled(.inverse) ?? false))
           case .foreground:
             if let foreground = attributes.foreground {
               result.append(.foreground(foreground))

--- a/Sources/TerminalInput/TerminalInput.swift
+++ b/Sources/TerminalInput/TerminalInput.swift
@@ -456,70 +456,60 @@ public final class TerminalInput {
         case 0:
           attributes = resetAttributes()
         case 1:
-          attributes.formats.insert(.isBold)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.bold)
+          attributes.setAttribute(.bold, enabled: true)
+          attributes.clearAttribute(.reset)
         case 2:
-          attributes.formats.insert(.isFaint)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.faint)
+          attributes.setAttribute(.faint, enabled: true)
+          attributes.clearAttribute(.reset)
         case 3:
-          attributes.formats.insert(.isItalic)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.italic)
+          attributes.setAttribute(.italic, enabled: true)
+          attributes.clearAttribute(.reset)
         case 4:
-          attributes.formats.insert(.isUnderlined)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.underlined)
+          attributes.setAttribute(.underlined, enabled: true)
+          attributes.clearAttribute(.reset)
         case 7:
-          attributes.formats.insert(.isInverse)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.inverse)
+          attributes.setAttribute(.inverse, enabled: true)
+          attributes.clearAttribute(.reset)
         case 22:
-          attributes.formats.remove(.isBold)
-          attributes.formats.remove(.isFaint)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.bold)
-          attributes.mark(.faint)
+          attributes.setAttribute(.bold, enabled: false)
+          attributes.setAttribute(.faint, enabled: false)
+          attributes.clearAttribute(.reset)
         case 23:
-          attributes.formats.remove(.isItalic)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.italic)
+          attributes.setAttribute(.italic, enabled: false)
+          attributes.clearAttribute(.reset)
         case 24:
-          attributes.formats.remove(.isUnderlined)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.underlined)
+          attributes.setAttribute(.underlined, enabled: false)
+          attributes.clearAttribute(.reset)
         case 27:
-          attributes.formats.remove(.isInverse)
-          attributes.formats.remove(.isReset)
-          attributes.mark(.inverse)
+          attributes.setAttribute(.inverse, enabled: false)
+          attributes.clearAttribute(.reset)
         case 30 ... 37:
           attributes.foreground = .standard( standardColor(from: value - 30) )
-          attributes.mark(.foreground)
-          attributes.formats.remove(.isReset)
+          attributes.setAttribute(.foreground, enabled: true)
+          attributes.clearAttribute(.reset)
         case 40 ... 47:
           attributes.background = .standard( standardColor(from: value - 40) )
-          attributes.mark(.background)
-          attributes.formats.remove(.isReset)
+          attributes.setAttribute(.background, enabled: true)
+          attributes.clearAttribute(.reset)
         case 90 ... 97:
           attributes.foreground = .bright( standardColor(from: value - 90) )
-          attributes.mark(.foreground)
-          attributes.formats.remove(.isReset)
+          attributes.setAttribute(.foreground, enabled: true)
+          attributes.clearAttribute(.reset)
         case 100 ... 107:
           attributes.background = .bright( standardColor(from: value - 100) )
-          attributes.mark(.background)
-          attributes.formats.remove(.isReset)
+          attributes.setAttribute(.background, enabled: true)
+          attributes.clearAttribute(.reset)
         case 38:
           if let color = parseExtendedColor(values: values, index: &index) {
             attributes.foreground = color
-            attributes.mark(.foreground)
-            attributes.formats.remove(.isReset)
+            attributes.setAttribute(.foreground, enabled: true)
+            attributes.clearAttribute(.reset)
           }
         case 48:
           if let color = parseExtendedColor(values: values, index: &index) {
             attributes.background = color
-            attributes.mark(.background)
-            attributes.formats.remove(.isReset)
+            attributes.setAttribute(.background, enabled: true)
+            attributes.clearAttribute(.reset)
           }
         default:
           break
@@ -533,11 +523,11 @@ public final class TerminalInput {
   /// ANSI defines SGR 0 as a full reset, so this helper applies the same idea to
   /// the high level structure.
   private func resetAttributes () -> AnsiFormat.Attributes {
-    var attributes = AnsiFormat.Attributes(formats: [.isReset])
+    var attributes = AnsiFormat.Attributes()
     attributes.foreground   = nil
     attributes.background   = nil
     attributes.clearMarks()
-    attributes.mark(.reset)
+    attributes.setAttribute(.reset, enabled: true)
     return attributes
   }
 

--- a/Tests/TerminalInputTests/TerminalInputTests.swift
+++ b/Tests/TerminalInputTests/TerminalInputTests.swift
@@ -35,8 +35,10 @@ final class TerminalInputTests: XCTestCase {
   func testSGRParsing () {
     let data    = Data("\u{001B}[1;31m".utf8)
     let tokens  = captureTokens(from: data)
-    let expectedAttributes = TerminalInput.AnsiFormat.Attributes(formats: [.isBold],
-                                                                 foreground: .standard(.red))
+    var expectedAttributes = TerminalInput.AnsiFormat.Attributes()
+    expectedAttributes.setAttribute(.bold, enabled: true)
+    expectedAttributes.foreground = .standard(.red)
+    expectedAttributes.setAttribute(.foreground, enabled: true)
     let expected = TerminalInput.Token.ansi( TerminalInput.AnsiFormat(sequence: "\u{001B}[1;31m",
                                                                       attributes: expectedAttributes) )
     XCTAssertEqual(tokens, [ expected ])
@@ -85,7 +87,7 @@ final class TerminalInputTests: XCTestCase {
     }
 
     XCTAssertEqual(formatToken.sequence, "\u{001B}[1;31m")
-    XCTAssertTrue(formatToken.attributes.formats.contains(.isBold))
+    XCTAssertTrue(formatToken.attributes.isAttributeEnabled(.bold) ?? false)
   }
 
   func testAttributeParserEnumeratesAttributes () {


### PR DESCRIPTION
## Summary
- replace the ANSI format flag set with a keyed attribute state map and helper accessors
- update SGR parsing and attribute parser logic to toggle styles through the new helpers
- adjust unit tests to assert against the updated attribute state API

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e3f3dc27108328b5b99a5e5fa21160