### PR TITLE
Handle default colour SGR codes

### DIFF
--- a/Sources/TerminalInput/AttributeParser.swift
+++ b/Sources/TerminalInput/AttributeParser.swift
@@ -13,7 +13,9 @@ extension TerminalInput.AnsiFormat {
     case underlined(Bool)
     case inverse(Bool)
     case foreground(Attributes.Color)
+    case foregroundDefault
     case background(Attributes.Color)
+    case backgroundDefault
   }
 
   /// Turns the parsed attribute structure into an ordered list of changes.  This
@@ -55,10 +57,14 @@ extension TerminalInput.AnsiFormat {
           case .foreground:
             if let foreground = attributes.foreground {
               result.append(.foreground(foreground))
+            } else if attributes.isAttributeEnabled(.foreground) == false {
+              result.append(.foregroundDefault)
             }
           case .background:
             if let background = attributes.background {
               result.append(.background(background))
+            } else if attributes.isAttributeEnabled(.background) == false {
+              result.append(.backgroundDefault)
             }
         }
       }

--- a/Sources/TerminalInput/TerminalInput.swift
+++ b/Sources/TerminalInput/TerminalInput.swift
@@ -493,9 +493,17 @@ public final class TerminalInput {
           attributes.foreground = .standard( standardColor(from: value - 30) )
           attributes.setAttribute(.foreground, enabled: true)
           if !sawReset { attributes.clearAttribute(.reset) }
+        case 39:
+          attributes.foreground = nil
+          attributes.setAttribute(.foreground, enabled: false)
+          if !sawReset { attributes.clearAttribute(.reset) }
         case 40 ... 47:
           attributes.background = .standard( standardColor(from: value - 40) )
           attributes.setAttribute(.background, enabled: true)
+          if !sawReset { attributes.clearAttribute(.reset) }
+        case 49:
+          attributes.background = nil
+          attributes.setAttribute(.background, enabled: false)
           if !sawReset { attributes.clearAttribute(.reset) }
         case 90 ... 97:
           attributes.foreground = .bright( standardColor(from: value - 90) )

--- a/Tests/TerminalInputTests/TerminalInputTests.swift
+++ b/Tests/TerminalInputTests/TerminalInputTests.swift
@@ -153,6 +153,38 @@ final class TerminalInputTests: XCTestCase {
     XCTAssertEqual(parsed, [ .bold(false), .faint(false) ])
   }
 
+  func testSGRForegroundDefaultParsing () {
+    let data    = Data("\u{001B}[39m".utf8)
+    let tokens  = captureTokens(from: data)
+    guard case let .ansi(formatToken) = tokens.first else {
+      XCTFail("Expected ANSI token")
+      return
+    }
+
+    XCTAssertNil(formatToken.attributes.foreground)
+    XCTAssertEqual(formatToken.attributes.isAttributeEnabled(.foreground), false)
+
+    let parser = TerminalInput.AnsiFormat.AttributeParser()
+    let parsed = parser.parse(attributes: formatToken.attributes)
+    XCTAssertEqual(parsed, [ .foregroundDefault ])
+  }
+
+  func testSGRBackgroundDefaultParsing () {
+    let data    = Data("\u{001B}[49m".utf8)
+    let tokens  = captureTokens(from: data)
+    guard case let .ansi(formatToken) = tokens.first else {
+      XCTFail("Expected ANSI token")
+      return
+    }
+
+    XCTAssertNil(formatToken.attributes.background)
+    XCTAssertEqual(formatToken.attributes.isAttributeEnabled(.background), false)
+
+    let parser = TerminalInput.AnsiFormat.AttributeParser()
+    let parsed = parser.parse(attributes: formatToken.attributes)
+    XCTAssertEqual(parsed, [ .backgroundDefault ])
+  }
+
   private func captureTokens ( from data: Data ) -> [TerminalInput.Token] {
     let input    = TerminalInput()
     var tokens   : [TerminalInput.Token] = []


### PR DESCRIPTION
## Summary
- ensure parseSGR treats SGR 39/49 as explicit colour resets and records the disabled attributes
- add AttributeParser cases for default foreground/background resets when no colour is supplied
- cover foreground/background default SGR sequences with new unit tests

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e3f8911e60832895ac27b94ea0baef