### PR TITLE
Add dedicated escape token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Your application is free to set the `dispatch` closure to `nil` at any time if y
 `TerminalInput.Token` is the core representation of user intent. Each case wraps a more specific type:
 
 * `.text(String)` – Printable characters decoded as UTF-8.
-* `.control(ControlKey)` – ASCII control codes (e.g. `.TAB`, `.RETURN`, `.ESC`).
+* `.control(ControlKey)` – ASCII control codes (e.g. `.TAB`, `.RETURN`).
 * `.cursor(CursorKey)` – Navigation keys such as `.up`, `.down`, `.home`, and `.pageDown`.
 * `.function(FunctionKey)` – Function keys (`.f(1)` through `.f(n)`), `.insert`, `.delete`, and `.unknown` for unusual sequences.
-* `.meta(MetaKey)` – Meta/alt combinations (e.g. `alt("x")`) or the bare escape key.
+* `.escape` – The standalone escape key or the ESC prefix that announces a control byte.
+* `.meta(MetaKey)` – Meta/alt combinations (e.g. `alt("x")`).
 * `.response(TerminalResponse)` – Asynchronous replies from the terminal such as cursor position reports or device attributes.
 * `.ansi(AnsiFormat)` – Select Graphic Rendition (SGR) sequences that modify colors and text styles.
 * `.mouse(MouseEvent)` – Pointer interactions including button presses, drags, and scroll events.
@@ -102,7 +103,7 @@ Your application is free to set the `dispatch` closure to `nil` at any time if y
 * `ControlKey` enumerates the classic ASCII control characters from `NULL` through `DEL`.
 * `CursorKey` covers the arrow cluster plus `home`, `end`, `pageUp`, and `pageDown`.
 * `FunctionKey` represents the numbered function keys, insert/delete, or stores the raw sequence when it cannot be classified.
-* `MetaKey` distinguishes between a standalone escape (`.escape`) and an alt-modified character (`.alt(Character)`).
+* `MetaKey` represents an alt-modified character (`.alt(Character)`).
 
 ### Terminal Responses
 

--- a/Sources/TerminalInput/TerminalInput.swift
+++ b/Sources/TerminalInput/TerminalInput.swift
@@ -30,6 +30,7 @@ public final class TerminalInput {
     case control(ControlKey)
     case cursor(CursorKey)
     case function(FunctionKey)
+    case escape
     case meta(MetaKey)
     case response(TerminalResponse)
     case ansi(AnsiFormat)
@@ -137,10 +138,9 @@ public final class TerminalInput {
   }
 
   /// Escape-derived combinations, such as pressing the option/alt key in
-  /// conjunction with a printable character, or the escape key by itself.
+  /// conjunction with a printable character.
   public enum MetaKey : Equatable {
     case alt(Character)
-    case escape
   }
 
   /// Messages sent from the terminal to report internal state.  These are most
@@ -269,7 +269,7 @@ public final class TerminalInput {
   /// Reference: Xterm Control Sequences, “Escape Sequences” overview.
   /// https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
   private func parseEscapeSequence () -> ParseResult {
-    guard buffer.count > 1 else { return .token( .meta(.escape), 1 ) }
+    guard buffer.count > 1 else { return .token( .escape, 1 ) }
     let indicator = buffer[1]
     switch indicator {
       case 0x5B : return parseCSISequence()
@@ -286,7 +286,7 @@ public final class TerminalInput {
     guard buffer.count > 1 else { return .needMore }
     let indicator = buffer[1]
     if indicator < 0x20 {
-      return .token( .meta(.escape), 1 )
+      return .token( .escape, 1 )
     }
     let length = 2
     let scalar    = UnicodeScalar(indicator)

--- a/Tests/TerminalInputTests/TerminalInputTests.swift
+++ b/Tests/TerminalInputTests/TerminalInputTests.swift
@@ -14,6 +14,17 @@ final class TerminalInputTests: XCTestCase {
     XCTAssertEqual(tokens, [ .control(.BEL) ])
   }
 
+  func testEscapeKeyEmission () {
+    let tokens = captureTokens(from: Data([0x1B]))
+    XCTAssertEqual(tokens, [ .escape ])
+  }
+
+  func testEscapeBeforeControlCharacter () {
+    let data   = Data([0x1B, 0x01])
+    let tokens = captureTokens(from: data)
+    XCTAssertEqual(tokens, [ .escape, .control(.SOH) ])
+  }
+
   func testArrowKeyParsing () {
     let data    = Data([0x1B, 0x5B, 0x41])
     let tokens  = captureTokens(from: data)


### PR DESCRIPTION
## Summary
- add a dedicated `Token.escape` case and restrict `MetaKey` to genuine alt chords
- update the escape/meta parsing paths to emit `.escape` for lone ESC bytes
- adjust tests and README documentation to reflect the new escape token semantics

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4cd8f1ad0832892f47730fb41fcd9