### PR TITLE
Adjust controlChord to expose chord glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Your application is free to set the `dispatch` closure to `nil` at any time if y
 
 ### Control and Navigation Enumerations
 
-* `ControlKey` enumerates the classic ASCII control characters from `NULL` through `DEL`.
+* `ControlKey` enumerates the classic ASCII control characters from `NULL` through `DEL` and can surface the glyph used in the canonical control chord via the `controlChord` property for presentation or logging.
 * `CursorKey` covers the arrow cluster plus `home`, `end`, `pageUp`, and `pageDown`.
 * `FunctionKey` represents the numbered function keys, insert/delete, or stores the raw sequence when it cannot be classified.
 * `MetaKey` represents an alt-modified character (`.alt(Character)`).

--- a/Sources/TerminalInput/TerminalInput.swift
+++ b/Sources/TerminalInput/TerminalInput.swift
@@ -76,6 +76,43 @@ public final class TerminalInput {
     case US
     case DEL
 
+    public var controlChord : Character? {
+      switch self {
+        case .NULL      : return "@"
+        case .SOH       : return "A"
+        case .STX       : return "B"
+        case .ETX       : return "C"
+        case .EOT       : return "D"
+        case .ENQ       : return "E"
+        case .ACK       : return "F"
+        case .BEL       : return "G"
+        case .BACKSPACE : return "H"
+        case .TAB       : return "I"
+        case .LF        : return "J"
+        case .VT        : return "K"
+        case .FF        : return "L"
+        case .RETURN    : return "M"
+        case .SO        : return "N"
+        case .SI        : return "O"
+        case .DLE       : return "P"
+        case .DC1       : return "Q"
+        case .DC2       : return "R"
+        case .DC3       : return "S"
+        case .DC4       : return "T"
+        case .NAK       : return "U"
+        case .SYN       : return "V"
+        case .ETB       : return "W"
+        case .CAN       : return "X"
+        case .EM        : return "Y"
+        case .SUB       : return "Z"
+        case .FS        : return "\\"
+        case .GS        : return "]"
+        case .RS        : return "^"
+        case .US        : return "_"
+        case .DEL       : return "?"
+      }
+    }
+
     public init? ( byte: UInt8 ) {
       switch byte {
         case 0x00 : self = .NULL

--- a/Tests/TerminalInputTests/TerminalInputTests.swift
+++ b/Tests/TerminalInputTests/TerminalInputTests.swift
@@ -14,6 +14,20 @@ final class TerminalInputTests: XCTestCase {
     XCTAssertEqual(tokens, [ .control(.BEL) ])
   }
 
+  func testControlKeyControlChordMappings () {
+    let letterChord : Character? = "A"
+    let tabChord    : Character? = "I"
+    let returnChord : Character? = "M"
+    let deleteChord : Character? = "?"
+    let nullChord   : Character? = "@"
+
+    XCTAssertEqual(TerminalInput.ControlKey.SOH.controlChord, letterChord)
+    XCTAssertEqual(TerminalInput.ControlKey.TAB.controlChord, tabChord)
+    XCTAssertEqual(TerminalInput.ControlKey.RETURN.controlChord, returnChord)
+    XCTAssertEqual(TerminalInput.ControlKey.DEL.controlChord, deleteChord)
+    XCTAssertEqual(TerminalInput.ControlKey.NULL.controlChord, nullChord)
+  }
+
   func testEscapeKeyEmission () {
     let tokens = captureTokens(from: Data([0x1B]))
     XCTAssertEqual(tokens, [ .escape ])


### PR DESCRIPTION
## Summary
- update `ControlKey.controlChord` to return the chord glyph as an optional `Character`
- refresh the unit test expectations to cover the character-based mapping
- clarify the README description of the property now that it yields the glyph character

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4e0770a68832884d3c5392e074f64